### PR TITLE
Add dead zone threshold setting for controller

### DIFF
--- a/src/defaults.cpp
+++ b/src/defaults.cpp
@@ -193,6 +193,7 @@ void setConfigDefaults(Configuration &cfg)
 #else
     AddDEF("joystickEnabled", false);
 #endif
+    AddDEF("axisThreshold", 0.3);
     AddDEF("upTolerance", 100);
     AddDEF("downTolerance", 100);
     AddDEF("leftTolerance", 100);

--- a/src/gui/widgets/tabs/setup_joystick.h
+++ b/src/gui/widgets/tabs/setup_joystick.h
@@ -31,6 +31,7 @@ class CheckBox;
 class DropDown;
 class Label;
 class NamesModel;
+class Slider;
 
 class Setup_Joystick final : public SetupTab
 {
@@ -56,8 +57,11 @@ class Setup_Joystick final : public SetupTab
         CheckBox *mJoystickEnabled A_NONNULLPOINTER;
         NamesModel *mNamesModel A_NONNULLPOINTER;
         DropDown *mNamesDropDown A_NONNULLPOINTER;
+        Label *mAxisThresholdLabel A_NONNULLPOINTER;
+        Slider *mAxisThresholdSlider A_NONNULLPOINTER;
         CheckBox *mUseInactiveCheckBox A_NONNULLPOINTER;
-        bool mOriginalJoystickEnabled A_NONNULLPOINTER;
+        float mAxisThreshold;
+        bool mOriginalJoystickEnabled;
 };
 
 #endif  // GUI_WIDGETS_TABS_SETUP_JOYSTICK_H

--- a/src/input/joystick.cpp
+++ b/src/input/joystick.cpp
@@ -47,7 +47,7 @@ bool Joystick::mEnabled = false;
 Joystick::Joystick(const int no) :
     mDirection(0),
     mJoystick(nullptr),
-    mAxisThreshold(0f),
+    mAxisThreshold(0.0f),
     mUpTolerance(0),
     mDownTolerance(0),
     mLeftTolerance(0),

--- a/src/input/joystick.cpp
+++ b/src/input/joystick.cpp
@@ -47,6 +47,7 @@ bool Joystick::mEnabled = false;
 Joystick::Joystick(const int no) :
     mDirection(0),
     mJoystick(nullptr),
+    mAxisThreshold(0f),
     mUpTolerance(0),
     mDownTolerance(0),
     mLeftTolerance(0),
@@ -188,6 +189,7 @@ bool Joystick::open()
     mCalibrated = config.getValueBool("joystick"
         + toString(mNumber) + "calibrated", false);
 
+    mAxisThreshold = config.getFloatValue("axisThreshold");
     mUpTolerance = config.getIntValue("upTolerance" + toString(mNumber));
     mDownTolerance = config.getIntValue("downTolerance" + toString(mNumber));
     mLeftTolerance = config.getIntValue("leftTolerance" + toString(mNumber));
@@ -251,16 +253,16 @@ void Joystick::logic()
     {
         // X-Axis
         int position = SDL_JoystickGetAxis(mJoystick, 0);
-        if (position >= mRightTolerance)
+        if (position >= mRightTolerance * mAxisThreshold)
             mDirection |= RIGHT;
-        else if (position <= mLeftTolerance)
+        else if (position <= mLeftTolerance * mAxisThreshold)
             mDirection |= LEFT;
 
         // Y-Axis
         position = SDL_JoystickGetAxis(mJoystick, 1);
-        if (position <= mUpTolerance)
+        if (position <= mUpTolerance * mAxisThreshold)
             mDirection |= UP;
-        else if (position >= mDownTolerance)
+        else if (position >= mDownTolerance * mAxisThreshold)
             mDirection |= DOWN;
 
 #ifdef DEBUG_JOYSTICK

--- a/src/input/joystick.h
+++ b/src/input/joystick.h
@@ -117,6 +117,9 @@ class Joystick final
         int getNumber() const noexcept2 A_WARN_UNUSED
         { return mNumber; }
 
+        void setAxisThreshold(const float f)
+        { mAxisThreshold = f; }
+
         void setUseInactive(const bool b)
         { mUseInactive = b; }
 
@@ -145,6 +148,7 @@ class Joystick final
 
         SDL_Joystick *mJoystick;
 
+        float mAxisThreshold;
         int mUpTolerance;
         int mDownTolerance;
         int mLeftTolerance;


### PR DESCRIPTION
Currently when after you calibrate joystick diagonal movement is not possible. One way to avoid that is to tilt the stick only slightly when calibrating but it would be hard to get tolerances even on all directions. Another way is to manually set tolerances in config.xml but that makes whole calibration meaningless.
So instead i propose a slider in joystick settings for dead zone threshold. To calibrate joystick you would simply roll the stick along edges couple times.