### PR TITLE
Fix linux build

### DIFF
--- a/src/progs/dyecmd/client.cpp
+++ b/src/progs/dyecmd/client.cpp
@@ -86,11 +86,9 @@ PRAGMA48(GCC diagnostic pop)
 #include <sys/time.h>
 #include "fs/specialfolder.h"
 #undef ERROR
-#endif  // WIN32
-
-#ifdef __clang__
+#else // WIN32
 #include <ctime>
-#endif  // __clang__
+#endif  // WIN32
 
 #ifdef ANDROID
 #ifndef USE_SDL2

--- a/src/resources/wallpaper.cpp
+++ b/src/resources/wallpaper.cpp
@@ -37,11 +37,9 @@
 
 #ifdef WIN32
 #include <sys/time.h>
-#endif  // WIN32
-
-#ifdef __clang__
+#else  // WIN32
 #include <ctime>
-#endif  // __clang__
+#endif  // WIN32
 
 #include "debug.h"
 

--- a/src/unittests/utils/dumplibs.cc
+++ b/src/unittests/utils/dumplibs.cc
@@ -57,7 +57,7 @@ TEST_CASE("dumplibs tests", "")
 #ifdef ENABLE_LIBXML
     SECTION("libxml2")
     {
-        const char **xmlVersion = __xmlParserVersion();
+        const char *const *xmlVersion = __xmlParserVersion();
         REQUIRE(xmlVersion != nullptr);
         REQUIRE(*xmlVersion != nullptr);
         REQUIRE(std::string(*xmlVersion) ==

--- a/src/utils/dumplibs.cpp
+++ b/src/utils/dumplibs.cpp
@@ -140,7 +140,7 @@ void dumpLibs()
     LIBXML_TEST_VERSION
 #endif  // LIBXML_TEST_VERSION
 #ifdef ENABLE_LIBXML
-    const char **xmlVersion = __xmlParserVersion();
+    const char *const *xmlVersion = __xmlParserVersion();
     if (xmlVersion != nullptr)
         logger->log(" libxml2: %s", *xmlVersion);
 #endif  // ENABLE_LIBXML

--- a/src/utils/xml/libxml.inc
+++ b/src/utils/xml/libxml.inc
@@ -24,6 +24,10 @@
 
 #ifdef ENABLE_LIBXML
 
+#ifdef HAVE_LIBXML2
+#include <libxml/parser.h>
+#endif  // HAVE_LIBXML2
+
 #include <libxml/xmlwriter.h>
 
 __XML_XMLWRITER_H__


### PR DESCRIPTION
Fixes building on Linux with:
gcc 13.2.1
libxml2 2.12.2

I believe more strict constness for __xmlParserVersion() should not affect compiling with other xml libraries.
Also I wasn't sure that including libxml/parser.h works for everyone, so I wrapped it in a #ifdef HAVE_LIBXML2