### PR TITLE
Controller improvements

### DIFF
--- a/src/defaults.cpp
+++ b/src/defaults.cpp
@@ -194,6 +194,7 @@ void setConfigDefaults(Configuration &cfg)
     AddDEF("joystickEnabled", false);
 #endif
     AddDEF("joystickTolerance", 0.1F);
+    AddDEF("useHatForMovement", true);
     AddDEF("logNpcInGui", true);
     AddDEF("download-music", true);
     AddDEF("guialpha", 0.8F);

--- a/src/defaults.cpp
+++ b/src/defaults.cpp
@@ -193,10 +193,7 @@ void setConfigDefaults(Configuration &cfg)
 #else
     AddDEF("joystickEnabled", false);
 #endif
-    AddDEF("upTolerance", 100);
-    AddDEF("downTolerance", 100);
-    AddDEF("leftTolerance", 100);
-    AddDEF("rightTolerance", 100);
+    AddDEF("joystickTolerance", 10000);
     AddDEF("logNpcInGui", true);
     AddDEF("download-music", true);
     AddDEF("guialpha", 0.8F);

--- a/src/defaults.cpp
+++ b/src/defaults.cpp
@@ -193,7 +193,7 @@ void setConfigDefaults(Configuration &cfg)
 #else
     AddDEF("joystickEnabled", false);
 #endif
-    AddDEF("joystickTolerance", 10000);
+    AddDEF("joystickTolerance", 0.1F);
     AddDEF("logNpcInGui", true);
     AddDEF("download-music", true);
     AddDEF("guialpha", 0.8F);

--- a/src/gui/sdlinput.cpp
+++ b/src/gui/sdlinput.cpp
@@ -172,6 +172,7 @@ void SDLInput::pushInput(const SDL_Event &event)
         }
 
         case SDL_JOYBUTTONDOWN:
+        case SDL_JOYHATMOTION:
         {
             const InputActionT actionId = inputManager.getActionByKey(event);
             if (actionId > InputAction::NO_VALUE)

--- a/src/gui/sdlinput.cpp
+++ b/src/gui/sdlinput.cpp
@@ -171,6 +171,20 @@ void SDLInput::pushInput(const SDL_Event &event)
             break;
         }
 
+        case SDL_JOYBUTTONDOWN:
+        {
+            const InputActionT actionId = inputManager.getActionByKey(event);
+            if (actionId > InputAction::NO_VALUE)
+            {
+                keyInput.setActionId(actionId);
+                keyInput.setType(KeyEventType::PRESSED);
+                mKeyInputQueue.push(keyInput);
+                keyInput.setType(KeyEventType::RELEASED);
+                mKeyInputQueue.push(keyInput);
+            }
+            break;
+        }
+
 #ifdef USE_SDL2
         case SDL_TEXTINPUT:
             keyInput.setType(KeyEventType::PRESSED);

--- a/src/gui/sdlinput.cpp
+++ b/src/gui/sdlinput.cpp
@@ -173,6 +173,7 @@ void SDLInput::pushInput(const SDL_Event &event)
 
         case SDL_JOYBUTTONDOWN:
         case SDL_JOYHATMOTION:
+        case SDL_JOYAXISMOTION:
         {
             const InputActionT actionId = inputManager.getActionByKey(event);
             if (actionId > InputAction::NO_VALUE)

--- a/src/gui/widgets/tabs/setup_joystick.cpp
+++ b/src/gui/widgets/tabs/setup_joystick.cpp
@@ -44,12 +44,6 @@
 
 Setup_Joystick::Setup_Joystick(const Widget2 *const widget) :
     SetupTab(widget),
-    mCalibrateLabel(new Label(this,
-        // TRANSLATORS: joystick settings tab label
-        _("Press the button to start calibration"))),
-    // TRANSLATORS: joystick settings tab button
-    mCalibrateButton(new Button(this, _("Calibrate"), "calibrate",
-        BUTTON_SKIN, this)),
     // TRANSLATORS: joystick settings tab button
     mDetectButton(new Button(this, _("Detect joysticks"), "detect",
         BUTTON_SKIN, this)),
@@ -76,7 +70,6 @@ Setup_Joystick::Setup_Joystick(const Widget2 *const widget) :
     mJoystickEnabled->setSelected(mOriginalJoystickEnabled);
     mJoystickEnabled->setActionEventId("joystick");
     mJoystickEnabled->addActionListener(this);
-    mCalibrateButton->setEnabled(mOriginalJoystickEnabled);
 
     int tolerance = config.getIntValue("joystickTolerance");
     mToleranceSlider->setValue(tolerance);
@@ -114,10 +107,8 @@ Setup_Joystick::Setup_Joystick(const Widget2 *const widget) :
 
     place(0, 3, mUseInactiveCheckBox, 1, 1);
     place(0, 4, mDetectButton, 1, 1);
-    place(0, 5, mCalibrateLabel, 1, 1);
-    place(0, 6, mCalibrateButton, 1, 1);
 
-    setDimension(Rect(0, 0, 365, 95));
+    setDimension(Rect(0, 0, 365, 60));
 }
 
 Setup_Joystick::~Setup_Joystick()
@@ -152,36 +143,11 @@ void Setup_Joystick::action(const ActionEvent &event)
             mNamesDropDown->setSelected(joystick->getNumber());
         }
     }
-    else
-    {
-        if (joystick == nullptr)
-            return;
-
-        if (joystick->isCalibrating())
-        {
-            // TRANSLATORS: joystick settings tab button
-            mCalibrateButton->setCaption(_("Calibrate"));
-            mCalibrateLabel->setCaption
-                // TRANSLATORS: joystick settings tab label
-                (_("Press the button to start calibration"));
-            joystick->finishCalibration();
-        }
-        else
-        {
-            // TRANSLATORS: joystick settings tab button
-            mCalibrateButton->setCaption(_("Stop"));
-            mCalibrateLabel->setCaption(
-                // TRANSLATORS: joystick settings tab label
-                _("Rotate the stick and don't press buttons"));
-            joystick->startCalibration();
-        }
-    }
 }
 
 void Setup_Joystick::setTempEnabled(const bool sel)
 {
     Joystick::setEnabled(sel);
-    mCalibrateButton->setEnabled(sel);
     if (joystick != nullptr)
     {
         if (sel)

--- a/src/gui/widgets/tabs/setup_joystick.cpp
+++ b/src/gui/widgets/tabs/setup_joystick.cpp
@@ -55,6 +55,11 @@ Setup_Joystick::Setup_Joystick(const Widget2 *const widget) :
         false, Modal_false, nullptr, std::string())),
     mToleranceLabel(new Label(this)),
     mToleranceSlider(new Slider(this, 0.01, 1, 0.01)),
+    mUseHatForMovementCheckBox(new CheckBox(this,
+        // TRANSLATORS: joystick settings tab checkbox
+        _("Use joystick hat (d-pad) for movement"),
+        config.getBoolValue("useHatForMovement"),
+        nullptr, std::string())),
     mUseInactiveCheckBox(new CheckBox(this,
         // TRANSLATORS: joystick settings tab checkbox
         _("Use joystick if client window inactive"),
@@ -105,10 +110,11 @@ Setup_Joystick::Setup_Joystick(const Widget2 *const widget) :
     place(0, 2, mToleranceSlider, 1, 1);
     place(1, 2, mToleranceLabel, 1, 1).setPadding(3);
 
-    place(0, 3, mUseInactiveCheckBox, 1, 1);
-    place(0, 4, mDetectButton, 1, 1);
+    place(0, 3, mUseHatForMovementCheckBox, 1, 1);
+    place(0, 4, mUseInactiveCheckBox, 1, 1);
+    place(0, 5, mDetectButton, 1, 1);
 
-    setDimension(Rect(0, 0, 365, 60));
+    setDimension(Rect(0, 0, 365, 75));
 }
 
 Setup_Joystick::~Setup_Joystick()
@@ -174,6 +180,8 @@ void Setup_Joystick::apply()
 
     config.setValue("joystickEnabled", Joystick::isEnabled());
 
+    config.setValue("useHatForMovement", mUseHatForMovementCheckBox->isSelected());
+    joystick->setUseHatForMovement(mUseHatForMovementCheckBox->isSelected());
     config.setValue("useInactiveJoystick", mUseInactiveCheckBox->isSelected());
     joystick->setUseInactive(mUseInactiveCheckBox->isSelected());
 

--- a/src/gui/widgets/tabs/setup_joystick.cpp
+++ b/src/gui/widgets/tabs/setup_joystick.cpp
@@ -54,7 +54,7 @@ Setup_Joystick::Setup_Joystick(const Widget2 *const widget) :
     mNamesDropDown(new DropDown(this, mNamesModel,
         false, Modal_false, nullptr, std::string())),
     mToleranceLabel(new Label(this)),
-    mToleranceSlider(new Slider(this, 1000, 32767, 1000)),
+    mToleranceSlider(new Slider(this, 0.01, 1, 0.01)),
     mUseInactiveCheckBox(new CheckBox(this,
         // TRANSLATORS: joystick settings tab checkbox
         _("Use joystick if client window inactive"),
@@ -71,10 +71,10 @@ Setup_Joystick::Setup_Joystick(const Widget2 *const widget) :
     mJoystickEnabled->setActionEventId("joystick");
     mJoystickEnabled->addActionListener(this);
 
-    int tolerance = config.getIntValue("joystickTolerance");
+    float tolerance = config.getFloatValue("joystickTolerance");
     mToleranceSlider->setValue(tolerance);
     // TRANSLATORS: joystick settings tab label
-    mToleranceLabel->setCaption(_("Axis tolerance: ") + strprintf("%d", tolerance));
+    mToleranceLabel->setCaption(_("Axis tolerance: ") + strprintf("%.2f", tolerance));
     mToleranceLabel->setWidth(150);
     mToleranceLabel->setHeight(20);
 
@@ -130,9 +130,9 @@ void Setup_Joystick::action(const ActionEvent &event)
     }
     else if (source == mToleranceSlider)
     {
-        int tolerance = mToleranceSlider->getValue();
+        float tolerance = mToleranceSlider->getValue();
         // TRANSLATORS: joystick settings tab label
-        mToleranceLabel->setCaption(_("Axis tolerance: ") + strprintf("%d", tolerance));
+        mToleranceLabel->setCaption(_("Axis tolerance: ") + strprintf("%.2f", tolerance));
     }
     else if (source == mDetectButton)
     {
@@ -177,7 +177,7 @@ void Setup_Joystick::apply()
     config.setValue("useInactiveJoystick", mUseInactiveCheckBox->isSelected());
     joystick->setUseInactive(mUseInactiveCheckBox->isSelected());
 
-    int tolerance = mToleranceSlider->getValue();
+    float tolerance = mToleranceSlider->getValue();
     config.setValue("joystickTolerance", tolerance);
     joystick->setTolerance(tolerance);
 }

--- a/src/gui/widgets/tabs/setup_joystick.h
+++ b/src/gui/widgets/tabs/setup_joystick.h
@@ -31,6 +31,7 @@ class CheckBox;
 class DropDown;
 class Label;
 class NamesModel;
+class Slider;
 
 class Setup_Joystick final : public SetupTab
 {
@@ -56,6 +57,8 @@ class Setup_Joystick final : public SetupTab
         CheckBox *mJoystickEnabled A_NONNULLPOINTER;
         NamesModel *mNamesModel A_NONNULLPOINTER;
         DropDown *mNamesDropDown A_NONNULLPOINTER;
+        Label *mToleranceLabel A_NONNULLPOINTER;
+        Slider *mToleranceSlider A_NONNULLPOINTER;
         CheckBox *mUseInactiveCheckBox A_NONNULLPOINTER;
         bool mOriginalJoystickEnabled A_NONNULLPOINTER;
 };

--- a/src/gui/widgets/tabs/setup_joystick.h
+++ b/src/gui/widgets/tabs/setup_joystick.h
@@ -51,8 +51,6 @@ class Setup_Joystick final : public SetupTab
         void setTempEnabled(const bool sel);
 
     private:
-        Label *mCalibrateLabel A_NONNULLPOINTER;
-        Button *mCalibrateButton A_NONNULLPOINTER;
         Button *mDetectButton A_NONNULLPOINTER;
         CheckBox *mJoystickEnabled A_NONNULLPOINTER;
         NamesModel *mNamesModel A_NONNULLPOINTER;

--- a/src/gui/widgets/tabs/setup_joystick.h
+++ b/src/gui/widgets/tabs/setup_joystick.h
@@ -57,6 +57,7 @@ class Setup_Joystick final : public SetupTab
         DropDown *mNamesDropDown A_NONNULLPOINTER;
         Label *mToleranceLabel A_NONNULLPOINTER;
         Slider *mToleranceSlider A_NONNULLPOINTER;
+        CheckBox *mUseHatForMovementCheckBox A_NONNULLPOINTER;
         CheckBox *mUseInactiveCheckBox A_NONNULLPOINTER;
         bool mOriginalJoystickEnabled A_NONNULLPOINTER;
 };

--- a/src/input/inputmanager.cpp
+++ b/src/input/inputmanager.cpp
@@ -417,7 +417,16 @@ std::string InputManager::getKeyStringLong(const InputActionT index) const
         else if (key.type == InputType::JOYSTICK)
         {
             // TRANSLATORS: long joystick button name. must be short.
-            str = strprintf(_("JButton%d"), key.value + 1);
+            if (key.value < Joystick::MAX_BUTTONS)
+                str = strprintf(_("JButton%d"), key.value + 1);
+            if (key.value == Joystick::KEY_UP)
+                str = _("JUp");
+            if (key.value == Joystick::KEY_DOWN)
+                str = _("JDown");
+            if (key.value == Joystick::KEY_LEFT)
+                str = _("JLeft");
+            if (key.value == Joystick::KEY_RIGHT)
+                str = _("JRight");
         }
         if (!str.empty())
         {
@@ -460,7 +469,16 @@ void InputManager::updateKeyString(const InputFunction &ki,
         else if (key.type == InputType::JOYSTICK)
         {
             // TRANSLATORS: short joystick button name. muse be very short
-            str = strprintf(_("JB%d"), key.value + 1);
+            if (key.value < Joystick::MAX_BUTTONS)
+                str = strprintf(_("JB%d"), key.value + 1);
+            if (key.value == Joystick::KEY_UP)
+                str = _("JUp");
+            if (key.value == Joystick::KEY_DOWN)
+                str = _("JDown");
+            if (key.value == Joystick::KEY_LEFT)
+                str = _("JLeft");
+            if (key.value == Joystick::KEY_RIGHT)
+                str = _("JRight");
         }
         if (!str.empty())
         {
@@ -650,6 +668,7 @@ bool InputManager::handleEvent(const SDL_Event &restrict event) restrict2
             break;
         }
         case SDL_JOYBUTTONDOWN:
+        case SDL_JOYHATMOTION:
         {
             updateConditionMask(true);
 //            joystick.handleActicateButton(event);
@@ -724,6 +743,7 @@ bool InputManager::handleEvent(const SDL_Event &restrict event) restrict2
 //            break;
 
         case SDL_JOYBUTTONDOWN:
+        case SDL_JOYHATMOTION:
             if ((joystick != nullptr) && joystick->validate())
             {
                 if (triggerAction(joystick->getActionVector(event)))

--- a/src/input/inputmanager.cpp
+++ b/src/input/inputmanager.cpp
@@ -710,7 +710,7 @@ bool InputManager::handleEvent(const SDL_Event &restrict event) restrict2
     if (gui != nullptr)
     {
         const bool res = gui->handleInput();
-        if (res && event.type == SDL_KEYDOWN)
+        if (res && (event.type == SDL_KEYDOWN || event.type == SDL_JOYBUTTONDOWN))
         {
             BLOCK_END("InputManager::handleEvent")
             return true;
@@ -1075,10 +1075,18 @@ InputActionT InputManager::getKeyIndex(const int value,
 InputActionT InputManager::getActionByKey(const SDL_Event &restrict event)
                                           const restrict2
 {
-    // for now support only keyboard events
     if (event.type == SDL_KEYDOWN || event.type == SDL_KEYUP)
     {
         const InputActionT idx = keyboard.getActionId(event);
+        if (CAST_S32(idx) >= 0 &&
+            checkKey(&inputActionData[CAST_SIZE(idx)]))
+        {
+            return idx;
+        }
+    }
+    if (joystick != nullptr && event.type == SDL_JOYBUTTONDOWN)
+    {
+        const InputActionT idx = joystick->getActionId(event);
         if (CAST_S32(idx) >= 0 &&
             checkKey(&inputActionData[CAST_SIZE(idx)]))
         {

--- a/src/input/inputmanager.cpp
+++ b/src/input/inputmanager.cpp
@@ -710,7 +710,8 @@ bool InputManager::handleEvent(const SDL_Event &restrict event) restrict2
     if (gui != nullptr)
     {
         const bool res = gui->handleInput();
-        if (res && (event.type == SDL_KEYDOWN || event.type == SDL_JOYBUTTONDOWN))
+        const bool joystickActionEvent = joystick != nullptr && joystick->isActionEvent(event);
+        if (res && (event.type == SDL_KEYDOWN || joystickActionEvent))
         {
             BLOCK_END("InputManager::handleEvent")
             return true;
@@ -1084,7 +1085,7 @@ InputActionT InputManager::getActionByKey(const SDL_Event &restrict event)
             return idx;
         }
     }
-    if (joystick != nullptr && event.type == SDL_JOYBUTTONDOWN)
+    if (joystick != nullptr && joystick->isActionEvent(event))
     {
         const InputActionT idx = joystick->getActionId(event);
         if (CAST_S32(idx) >= 0 &&

--- a/src/input/inputmanager.cpp
+++ b/src/input/inputmanager.cpp
@@ -427,6 +427,10 @@ std::string InputManager::getKeyStringLong(const InputActionT index) const
                 str = _("JLeft");
             if (key.value == Joystick::KEY_RIGHT)
                 str = _("JRight");
+            if (key.value >= Joystick::KEY_NEGATIVE_AXIS_FIRST && key.value < Joystick::KEY_POSITIVE_AXIS_FIRST)
+                str = strprintf(_("JAxis%dMinus"), key.value - Joystick::KEY_NEGATIVE_AXIS_FIRST);
+            if (key.value >= Joystick::KEY_POSITIVE_AXIS_FIRST && key.value < Joystick::KEY_END)
+                str = strprintf(_("JAxis%dPlus"), key.value - Joystick::KEY_POSITIVE_AXIS_FIRST);
         }
         if (!str.empty())
         {
@@ -479,6 +483,10 @@ void InputManager::updateKeyString(const InputFunction &ki,
                 str = _("JLeft");
             if (key.value == Joystick::KEY_RIGHT)
                 str = _("JRight");
+            if (key.value >= Joystick::KEY_NEGATIVE_AXIS_FIRST && key.value < Joystick::KEY_POSITIVE_AXIS_FIRST)
+                str = strprintf(_("JA%d-"), key.value - Joystick::KEY_NEGATIVE_AXIS_FIRST);
+            if (key.value >= Joystick::KEY_POSITIVE_AXIS_FIRST && key.value < Joystick::KEY_END)
+                str = strprintf(_("JA%d+"), key.value - Joystick::KEY_POSITIVE_AXIS_FIRST);
         }
         if (!str.empty())
         {
@@ -669,6 +677,7 @@ bool InputManager::handleEvent(const SDL_Event &restrict event) restrict2
         }
         case SDL_JOYBUTTONDOWN:
         case SDL_JOYHATMOTION:
+        case SDL_JOYAXISMOTION:
         {
             updateConditionMask(true);
 //            joystick.handleActicateButton(event);
@@ -745,6 +754,7 @@ bool InputManager::handleEvent(const SDL_Event &restrict event) restrict2
 
         case SDL_JOYBUTTONDOWN:
         case SDL_JOYHATMOTION:
+        case SDL_JOYAXISMOTION:
             if ((joystick != nullptr) && joystick->validate())
             {
                 if (triggerAction(joystick->getActionVector(event)))

--- a/src/input/joystick.cpp
+++ b/src/input/joystick.cpp
@@ -326,6 +326,11 @@ void Joystick::update()
         mKeyTimeMap, InputType::JOYSTICK);
 }
 
+bool Joystick::isActionEvent(const SDL_Event &event)
+{
+    return getButtonFromEvent(event) >= 0;
+}
+
 KeysVector *Joystick::getActionVector(const SDL_Event &event)
 {
     const int i = getButtonFromEvent(event);

--- a/src/input/joystick.cpp
+++ b/src/input/joystick.cpp
@@ -177,12 +177,12 @@ bool Joystick::open()
 
 #ifdef __SWITCH__
     config.setValue("joystick" + toString(mNumber) + "calibrated", true);
-    config.setValue("joystickTolerance" + toString(mNumber), 10000);
+    config.setValue("joystickTolerance", 10000);
 #endif
     mCalibrated = config.getValueBool("joystick"
         + toString(mNumber) + "calibrated", false);
 
-    mTolerance = config.getIntValue("joystickTolerance" + toString(mNumber));
+    mTolerance = config.getIntValue("joystickTolerance");
     mUseInactive = config.getBoolValue("useInactiveJoystick");
 
     return true;
@@ -326,7 +326,7 @@ void Joystick::finishCalibration()
     mCalibrated = true;
     mCalibrating = false;
     config.setValue("joystick" + toString(mNumber) + "calibrated", true);
-    config.setValue("joystickTolerance" + toString(mNumber), mTolerance);
+    config.setValue("joystickTolerance", mTolerance);
 }
 
 bool Joystick::buttonPressed(const unsigned char no) const

--- a/src/input/joystick.cpp
+++ b/src/input/joystick.cpp
@@ -342,6 +342,16 @@ KeysVector *Joystick::getActionVectorByKey(const int i)
     return nullptr;
 }
 
+InputActionT Joystick::getActionId(const SDL_Event &event)
+{
+    const int i = getButtonFromEvent(event);
+    if (i < 0)
+        return InputAction::NO_VALUE;
+    if (mKeyToId.find(i) != mKeyToId.end())
+        return mKeyToId[i];
+    return InputAction::NO_VALUE;
+}
+
 int Joystick::getButtonFromEvent(const SDL_Event &event) const
 {
     if (event.type == SDL_JOYBUTTONDOWN)

--- a/src/input/joystick.cpp
+++ b/src/input/joystick.cpp
@@ -174,9 +174,9 @@ bool Joystick::open()
         mButtonsNumber = MAX_BUTTONS;
 
 #ifdef __SWITCH__
-    config.setValue("joystickTolerance", 10000);
+    config.setValue("joystickTolerance", 0.1F);
 #endif
-    mTolerance = config.getIntValue("joystickTolerance");
+    mTolerance = config.getFloatValue("joystickTolerance");
     mUseInactive = config.getBoolValue("useInactiveJoystick");
 
     return true;
@@ -228,16 +228,16 @@ void Joystick::logic()
     {
         // X-Axis
         int position = SDL_JoystickGetAxis(mJoystick, 0);
-        if (position >= mTolerance)
+        if (position >= mTolerance * AXIS_MAX)
             mDirection |= RIGHT;
-        else if (position <= -mTolerance)
+        else if (position <= mTolerance * AXIS_MIN)
             mDirection |= LEFT;
 
         // Y-Axis
         position = SDL_JoystickGetAxis(mJoystick, 1);
-        if (position <= -mTolerance)
+        if (position <= mTolerance * AXIS_MIN)
             mDirection |= UP;
-        else if (position >= mTolerance)
+        else if (position >= mTolerance * AXIS_MAX)
             mDirection |= DOWN;
 
 #ifdef DEBUG_JOYSTICK

--- a/src/input/joystick.cpp
+++ b/src/input/joystick.cpp
@@ -453,37 +453,8 @@ void Joystick::handleRepeat(const int time)
     BLOCK_START("Joystick::handleRepeat")
     FOR_EACH (KeyTimeMapIter, it, mKeyTimeMap)
     {
-        bool repeat(false);
         const int key = (*it).first;
-        if (key >= 0 && key < mButtonsNumber)
-        {
-            if (mActiveButtons[key])
-                repeat = true;
-        }
-        if (!mUseHatForMovement)
-        {
-            if (key == KEY_UP && (mHatPosition & UP) != 0)
-                repeat = true;
-            if (key == KEY_DOWN && (mHatPosition & DOWN) != 0)
-                repeat = true;
-            if (key == KEY_LEFT && (mHatPosition & LEFT) != 0)
-                repeat = true;
-            if (key == KEY_RIGHT && (mHatPosition & RIGHT) != 0)
-                repeat = true;
-        }
-        if (key >= KEY_NEGATIVE_AXIS_FIRST && key < KEY_POSITIVE_AXIS_FIRST)
-        {
-            const int axis = key - KEY_NEGATIVE_AXIS_FIRST;
-            if (axis >= RESERVED_AXES && mAxesPositions[axis] < mTolerance * AXIS_MIN)
-                repeat = true;
-        }
-        if (key >= KEY_POSITIVE_AXIS_FIRST && key < KEY_END)
-        {
-            const int axis = key - KEY_POSITIVE_AXIS_FIRST;
-            if (axis >= RESERVED_AXES && mAxesPositions[axis] > mTolerance * AXIS_MAX)
-                repeat = true;
-        }
-        if (repeat)
+        if (buttonPressed(key))
         {
             int &keyTime = (*it).second;
             if (time > keyTime && abs(time - keyTime)

--- a/src/input/joystick.h
+++ b/src/input/joystick.h
@@ -128,6 +128,9 @@ class Joystick final
         void setTolerance(const float tolerance)
         { mTolerance = tolerance; }
 
+        void setUseHatForMovement(const bool b)
+        { mUseHatForMovement = b; }
+
         void setUseInactive(const bool b)
         { mUseInactive = b; }
 
@@ -160,6 +163,7 @@ class Joystick final
         float mTolerance;
         int mNumber;
         int mButtonsNumber;
+        bool mUseHatForMovement;
         bool mUseInactive;
         bool mHaveHats;
 

--- a/src/input/joystick.h
+++ b/src/input/joystick.h
@@ -53,6 +53,9 @@ class Joystick final
             RIGHT = 8
         };
 
+        static const int AXIS_MIN = -32768;
+        static const int AXIS_MAX = 32767;
+
         /**
          * Initializes the joystick subsystem.
          */
@@ -110,7 +113,7 @@ class Joystick final
         int getNumber() const noexcept2 A_WARN_UNUSED
         { return mNumber; }
 
-        void setTolerance(const int tolerance)
+        void setTolerance(const float tolerance)
         { mTolerance = tolerance; }
 
         void setUseInactive(const bool b)
@@ -141,7 +144,7 @@ class Joystick final
 
         SDL_Joystick *mJoystick;
 
-        int mTolerance;
+        float mTolerance;
         int mNumber;
         int mButtonsNumber;
         bool mUseInactive;

--- a/src/input/joystick.h
+++ b/src/input/joystick.h
@@ -136,6 +136,8 @@ class Joystick final
 
         void update();
 
+        bool isActionEvent(const SDL_Event &event) A_WARN_UNUSED;
+
         KeysVector *getActionVector(const SDL_Event &event) A_WARN_UNUSED;
 
         KeysVector *getActionVectorByKey(const int i) A_WARN_UNUSED;

--- a/src/input/joystick.h
+++ b/src/input/joystick.h
@@ -42,8 +42,15 @@ class Joystick final
             MAX_BUTTONS = 64
         };
 
+        enum
+        {
+            RESERVED_AXES = 2,  // reserved for movement
+            MAX_AXES = 8  // number of axes we can handle
+        };
+
         /**
-         * Additional "buttons" for hat 0 (d-pad).
+         * Additional "buttons" for hat 0 (d-pad),
+         * sticks and triggers.
          */
         enum
         {
@@ -51,7 +58,9 @@ class Joystick final
             KEY_DOWN,
             KEY_LEFT,
             KEY_RIGHT,
-            KEY_LAST = KEY_RIGHT
+            KEY_NEGATIVE_AXIS_FIRST,
+            KEY_POSITIVE_AXIS_FIRST = KEY_NEGATIVE_AXIS_FIRST + MAX_AXES,
+            KEY_END = KEY_POSITIVE_AXIS_FIRST + MAX_AXES
         };
 
         /**
@@ -160,12 +169,14 @@ class Joystick final
         unsigned char mDirection;
 
         unsigned char mHatPosition;
+        int mAxesPositions[MAX_AXES];
         bool mActiveButtons[MAX_BUTTONS];
 
         SDL_Joystick *mJoystick;
 
         float mTolerance;
         int mNumber;
+        int mAxesNumber;
         int mButtonsNumber;
         bool mUseHatForMovement;
         bool mUseInactive;

--- a/src/input/joystick.h
+++ b/src/input/joystick.h
@@ -93,13 +93,6 @@ class Joystick final
          */
         void logic();
 
-        void startCalibration();
-
-        void finishCalibration();
-
-        bool isCalibrating() const noexcept2 A_WARN_UNUSED
-        { return mCalibrating; }
-
         bool buttonPressed(const unsigned char no) const A_WARN_UNUSED;
 
         bool isUp() const noexcept2 A_WARN_UNUSED
@@ -149,9 +142,7 @@ class Joystick final
         SDL_Joystick *mJoystick;
 
         int mTolerance;
-        bool mCalibrating;
         int mNumber;
-        bool mCalibrated;
         int mButtonsNumber;
         bool mUseInactive;
         bool mHaveHats;
@@ -167,8 +158,6 @@ class Joystick final
          */
         static bool mEnabled;
         static int joystickCount;
-
-        void doCalibration();
 };
 
 extern Joystick *joystick;

--- a/src/input/joystick.h
+++ b/src/input/joystick.h
@@ -170,6 +170,7 @@ class Joystick final
 
         unsigned char mHatPosition;
         int mAxesPositions[MAX_AXES];
+        bool mIsTrigger[MAX_AXES];
         bool mActiveButtons[MAX_BUTTONS];
 
         SDL_Joystick *mJoystick;

--- a/src/input/joystick.h
+++ b/src/input/joystick.h
@@ -140,6 +140,8 @@ class Joystick final
 
         KeysVector *getActionVectorByKey(const int i) A_WARN_UNUSED;
 
+        InputActionT getActionId(const SDL_Event &event) A_WARN_UNUSED;
+
         int getButtonFromEvent(const SDL_Event &event) const A_WARN_UNUSED;
 
         bool isActionActive(const InputActionT index) const A_WARN_UNUSED;

--- a/src/input/joystick.h
+++ b/src/input/joystick.h
@@ -117,6 +117,9 @@ class Joystick final
         int getNumber() const noexcept2 A_WARN_UNUSED
         { return mNumber; }
 
+        void setTolerance(const int tolerance)
+        { mTolerance = tolerance; }
+
         void setUseInactive(const bool b)
         { mUseInactive = b; }
 

--- a/src/input/joystick.h
+++ b/src/input/joystick.h
@@ -43,6 +43,18 @@ class Joystick final
         };
 
         /**
+         * Additional "buttons" for hat 0 (d-pad).
+         */
+        enum
+        {
+            KEY_UP = MAX_BUTTONS,
+            KEY_DOWN,
+            KEY_LEFT,
+            KEY_RIGHT,
+            KEY_LAST = KEY_RIGHT
+        };
+
+        /**
          * Directions, to be used as bitmask values.
          */
         enum
@@ -96,7 +108,7 @@ class Joystick final
          */
         void logic();
 
-        bool buttonPressed(const unsigned char no) const A_WARN_UNUSED;
+        bool buttonPressed(const int no) const A_WARN_UNUSED;
 
         bool isUp() const noexcept2 A_WARN_UNUSED
         { return mEnabled && ((mDirection & UP) != 0); }
@@ -140,6 +152,7 @@ class Joystick final
     protected:
         unsigned char mDirection;
 
+        unsigned char mHatPosition;
         bool mActiveButtons[MAX_BUTTONS];
 
         SDL_Joystick *mJoystick;

--- a/src/input/joystick.h
+++ b/src/input/joystick.h
@@ -145,10 +145,7 @@ class Joystick final
 
         SDL_Joystick *mJoystick;
 
-        int mUpTolerance;
-        int mDownTolerance;
-        int mLeftTolerance;
-        int mRightTolerance;
+        int mTolerance;
         bool mCalibrating;
         int mNumber;
         bool mCalibrated;


### PR DESCRIPTION
This PR aims to start a discussion about proposed changes:

- Remove joystick calibration feature and replace it with a slider to set the tolerance directly. This tolerance value is used for all axes and is shared between all joysticks.
- Add "virtual" buttons for d-pad and axes (sticks and triggers) to allow binding actions to them.
- Basic GUI support for controller. No default scheme is suggested, need to assign buttons to actions manually.